### PR TITLE
fix(tailscale): drop un-evaluable Connector healthCheck (fixes perpetual NotReady)

### DIFF
--- a/apps/network/tailscale/config.yaml
+++ b/apps/network/tailscale/config.yaml
@@ -22,8 +22,9 @@ spec:
   # Wait for the operator to be ready (installs CRDs)
   dependsOn:
     - name: tailscale
-  healthChecks:
-    - apiVersion: tailscale.com/v1alpha1
-      kind: Connector
-      name: home-network-router
-      namespace: network
+  # NOTE: no healthCheck on the Connector. The Tailscale operator reports
+  # readiness via a non-standard `ConnectorReady` condition and does not set a
+  # top-level status.observedGeneration, so Flux's kstatus evaluates it as
+  # `Unknown` forever and the Kustomization perpetually times out (9m30s) even
+  # though the Connector is healthy. Gating on it is not possible until the
+  # CRD exposes a standard `Ready` condition.


### PR DESCRIPTION
## Problem
`tailscale-config` Kustomization sits at `Ready: Unknown / Reconciliation in progress` and cycles through failures:
```
health check failed after 9m30s: timeout waiting for:
[Connector/network/home-network-router status: 'Unknown']
```

## Root cause
The Connector **is** healthy (`ConnectorReady: True`, routing `192.168.1.0/24`, has tailnet IPs). But Flux evaluates health via **kstatus**, which needs a standard `Ready` condition and a top-level `status.observedGeneration`. The Tailscale operator provides neither — it uses a custom `ConnectorReady` condition and only sets `observedGeneration` *inside* the condition. So kstatus returns `Unknown` and the health check can never pass — a permanent 9m30s flap.

## Fix
Remove the Connector health check. Nothing `dependsOn: tailscale-config`, so there's no gating value being lost, and the Connector's real health is unaffected. The Kustomization will report Ready once its server-side apply succeeds.

(If a future tailscale-operator version exposes a standard `Ready` condition, the health check can be restored.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)