### PR TITLE
fix(hoarder): enable meilisearch dumpless upgrade for v1.48 (fixes crashloop)

### DIFF
--- a/apps/home/hoarder/app/helm-release.yaml
+++ b/apps/home/hoarder/app/helm-release.yaml
@@ -29,6 +29,11 @@ spec:
             image:
               repository: getmeili/meilisearch
               tag: v1.48.3
+            env:
+              # v1.48 refuses to start on a v1.34 database. This performs an
+              # in-place migration on startup (Meilisearch >=1.12). Safe to
+              # remove once the meili-data volume has been migrated to 1.48.
+              MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE: "true"
             envFrom:
               - secretRef:
                   name: hoarder-secrets


### PR DESCRIPTION
## Problem
After #1240 bumped meilisearch v1.34.2 → **v1.48.3**, the `hoarder-meili` pod crash-loops:
```
ERROR meilisearch: Your database version (1.34.2) is incompatible with your
current engine version (1.48.3).
```
Meilisearch does not auto-migrate across incompatible versions.

## Fix
Set `MEILI_EXPERIMENTAL_DUMPLESS_UPGRADE=true` on the meili container. Meilisearch ≥1.12 uses this to migrate the database **in place** on startup — no manual dump/import, index preserved. The flag only acts when the DB and engine versions differ, and can be removed once the volume is migrated.

## Alternatives (if you'd rather)
- **Revert #1240** to pin meili back to `v1.34.x` (I held this major originally for exactly this reason).
- **Wipe the `meili-data` PVC** — the index is derived data; hoarder/karakeep can rebuild it from its main DB. Slower (full re-index) but avoids the experimental flag.

Overlay verified with `kubectl kustomize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)